### PR TITLE
fix: Append Cargo.toml to manifest path on beta

### DIFF
--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -20,7 +20,7 @@ def target_binary_name(target):
 class Manifest(object):
     def __init__(self, dir, version):
         # the --manifest-path behaviour changed in https://github.com/rust-lang/cargo/pull/1955
-        if version in ('nightly', 'dev'):
+        if version in ('nightly', 'dev', 'beta'):
             path = os.path.join(dir, 'Cargo.toml')
         else:
             path = dir


### PR DESCRIPTION
Currently travis-cargo doesn't work anymore. See [this Travis build](https://travis-ci.org/badboy/lzf-rs/jobs/80604892).

Latest cargo bundled in beta is already using the new code and thus needs the `Cargo.toml` appended.

The code probably needs an update as soon as stable gets this as well.