### PR TITLE
Better lib name detection

### DIFF
--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -59,8 +59,9 @@ class Manifest(object):
     def targets(self):
         return self.manifest['targets']
     def lib_name(self):
-        for target in self.targets():
-            if 'lib' in target['kind']:
+        libtypes = ['lib', 'dylib', 'staticlib', 'rlib']
+        for target in man['targets']:
+            if any(ltype in target['kind'] for ltype in libtypes):
                 return target['name'].replace('-', '_')
         return None
 

--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -60,7 +60,7 @@ class Manifest(object):
         return self.manifest['targets']
     def lib_name(self):
         libtypes = ['lib', 'dylib', 'staticlib', 'rlib']
-        for target in man['targets']:
+        for target in self.targets():
             if any(ltype in target['kind'] for ltype in libtypes):
                 return target['name'].replace('-', '_')
         return None


### PR DESCRIPTION
Fixes #31
I'm having the same problem. A build which fails to detect my library name is [here](https://travis-ci.org/urschrei/lonlat_bng/jobs/115834551#L363)

I thought that logic in [this line](https://github.com/huonw/travis-cargo/blob/90508c266b39aa7a8298959d064a4a2cd5c4901c/travis_cargo.py#L63) worked for substring detection, but I've just stepped through it and it's not grabbing the name out of `['u'rlib', u'dylib', u'staticlib']` for me. This is a bit more robust.