### PR TITLE
Fix coveralls integration

### DIFF
--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -156,8 +156,8 @@ def build_kcov(use_sudo, verify):
             deps += ' binutils-dev'
     init = deps + '''
     wget https://github.com/SimonKagstrom/kcov/archive/v31.zip
-    unzip master.zip
-    mv kcov-master kcov
+    unzip v31.zip
+    mv kcov-31 kcov
     mkdir kcov/build
     '''
     for line in init.split('\n'):

--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -220,7 +220,9 @@ def raw_coverage(use_sudo, verify, link_dead_code, test_args,
         exclude_pattern_arg = '--exclude-pattern=/.cargo'
         if exclude_pattern:
             exclude_pattern_arg += ',{}'.format(exclude_pattern)
-        kcov_args += [exclude_pattern_arg, 'target/kcov-' + binary,
+        outdir = 'target/kcov-' + binary
+        os.makedirs(outdir)
+        kcov_args += [exclude_pattern_arg, outdir,
                       'target/debug/' + binary]
         print('Running: {}'.format(' '.join(kcov_args)))
         run(*kcov_args, env={'LD_LIBRARY_PATH': ld_library_path})

--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -155,9 +155,9 @@ def build_kcov(use_sudo, verify):
         if verify:
             deps += ' binutils-dev'
     init = deps + '''
-    wget https://github.com/SimonKagstrom/kcov/archive/v31.zip
-    unzip v31.zip
-    mv kcov-31 kcov
+    wget https://github.com/SimonKagstrom/kcov/archive/v33.zip
+    unzip v33.zip
+    mv kcov-33 kcov
     mkdir kcov/build
     '''
     for line in init.split('\n'):

--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -2,6 +2,10 @@ from __future__ import print_function
 import argparse
 import os, sys, subprocess, json, re
 
+
+KCOV_RELEASE = "33"
+
+
 def run(*args, **kwargs):
     # use the current environment, but override the vars the caller
     # specified
@@ -155,11 +159,11 @@ def build_kcov(use_sudo, verify):
         if verify:
             deps += ' binutils-dev'
     init = deps + '''
-    wget https://github.com/SimonKagstrom/kcov/archive/v33.zip
-    unzip v33.zip
-    mv kcov-33 kcov
+    wget https://github.com/SimonKagstrom/kcov/archive/v{ver}.zip
+    unzip v{ver}.zip
+    mv kcov-{ver} kcov
     mkdir kcov/build
-    '''
+    '''.format(ver=KCOV_RELEASE)
     for line in init.split('\n'):
         line = line.strip()
         if line:

--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -32,8 +32,8 @@ def run_output(*args, **kwargs):
 
     try:
         output = subprocess.check_output(args,
-                                         stderr=sys.stderr,
-                                         env = env)
+                                         stderr=subprocess.STDOUT,
+                                         env=env)
     except subprocess.CalledProcessError as e:
         print(e.output.decode('utf-8'))
         exit(e.returncode)

--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -228,6 +228,7 @@ def raw_coverage(use_sudo, verify, link_dead_code, test_args,
     print(merge_msg)
     kcov_args = [kcov, '--merge'] + kcov_merge_args + [kcov_merge_dir]
     kcov_args += ('target/kcov-' + b for b in test_binaries)
+    print(" ".join(kcov_args))
     run(*kcov_args)
 
 def coverage(version, manifest, args):

--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -155,7 +155,7 @@ def build_kcov(use_sudo, verify):
         if verify:
             deps += ' binutils-dev'
     init = deps + '''
-    wget https://github.com/SimonKagstrom/kcov/archive/master.zip
+    wget https://github.com/SimonKagstrom/kcov/archive/v31.zip
     unzip master.zip
     mv kcov-master kcov
     mkdir kcov/build


### PR DESCRIPTION
This PR provides a fix for the broken coveralls integration.

1. It also looks in stderr for the output of cargo. Otherwise, the test binary won't be found by the regex.
2. It pins kcov to a specific version, in order to avoid unexpected changes in the behavior of kcov.
3. It creates the kcov output directory before execution. Otherwise, kcov would exit with an error.

This fixes issue #58.
Note that this PR subsumes #64, #61, and #55.