### PR TITLE
Don't clone entire history of ghp-import

### DIFF
--- a/travis_cargo.py
+++ b/travis_cargo.py
@@ -144,7 +144,7 @@ def doc_upload(version, manifest, args):
         with open('target/doc/index.html', 'w') as f:
             f.write('<meta http-equiv=refresh content=0;url=%s/index.html>' % lib_name)
 
-        run('git', 'clone', 'https://github.com/davisp/ghp-import')
+        run('git', 'clone', '--depth', '1', 'https://github.com/davisp/ghp-import')
         run(sys.executable, './ghp-import/ghp_import.py', '-n', '-m', msg, 'target/doc')
         run_filter(token, 'git', 'push', '-fq', 'https://%s@github.com/%s.git' % (token, repo), 'gh-pages')
 


### PR DESCRIPTION
Since the history is not needed, this just pulls the latest. However, using git might be better replaced by just downloading the file directly since it's a single script: https://raw.githubusercontent.com/davisp/ghp-import/master/ghp_import.py